### PR TITLE
set version for pytest-html, add python-dateutil

### DIFF
--- a/tew/requirements.txt
+++ b/tew/requirements.txt
@@ -1,11 +1,13 @@
 fabric==2.4.0
 pytest==3.6.0
 pytest-axe==1.1.6
+pytest-html==1.20.0
 pytest-repeat==0.4.1
 pytest-rerunfailures==4.1
 pytest-selenium==1.13.0
 pytest-test-groups==1.0.3
 pytest-xdist==1.22.2
+python-dateutil==2.8.0
 requests==2.20.0
 selenium==3.141.0
 git+https://github.com/yashaka/selene.git@1.0.0a13#egg=selene


### PR DESCRIPTION
this container uses an older version of pytest. to rebuild it, we found
we needed to pin the version of pytest-html.

also adding python-dateutil package. it is useful when dealing with
dates and timezones.