### PR TITLE
match uid and gid to host's uid and gid

### DIFF
--- a/tew/Dockerfile
+++ b/tew/Dockerfile
@@ -4,59 +4,65 @@ MAINTAINER RStudio Quality <qa@rstudio.com>
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
+# No interactive frontend during docker build
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN=true
+
 # Install basic development & debugging tools
 RUN set -ex; \
-        \
-        apt-get update; \
-        apt-get install -y --no-install-recommends \
-            bash \
-            curl \
-            jq \
-            make \
-            openssh-server \
-            wget; \
-        \
-        rm -rf /var/lib/apt/lists/*;
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        bash \
+        curl \
+        jq \
+        libnss-wrapper \
+        make \
+        openssh-server \
+        sudo \
+        vim \
+        wget; \
+    \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/*;
 
 
 # Copy in Python package requirements files
 WORKDIR /opt/work
-COPY Pipfile Pipfile
-COPY Pipfile.lock Pipfile.lock
+COPY Pipfile Pipfile.lock /opt/work/
 
 # Install build dependencies and Python packages
 # these build dependencies are only needed to compile
 # Python packages. After installing the packages,
 # purge them to keep the final layer small.
 RUN set -ex; \
-        \
-        buildDeps=" \
-            gcc \
-            git \
-            libc6-dev \
-            libffi-dev \
-            libssl-dev \
-        "; \
-        \
-        pythonPkgs=" \
-            ipython3 \
-            python3 \
-            python3-dev \
-            python3-pip \
-        "; \
-        \
-        apt-get update; \
-        apt-get install -y $buildDeps $pythonPkgs --no-install-recommends; \
-        rm -rf /var/lib/apt/lists/*; \
-        \
-        ln -s /usr/bin/python3 /usr/bin/python; \
-        ln -s /usr/bin/pydoc3 /usr/bin/pydoc; \
-        \
-        python3 -m pip install --no-cache-dir pipenv; \
-        pipenv install --system --dev --pre; \
-        rm -f Pipfile Pipfile.lock; \
-        \
-        apt-get purge -y --auto-remove $buildDeps;
+    \
+    buildDeps=" \
+        gcc \
+        git \
+        libc6-dev \
+        libffi-dev \
+        libssl-dev \
+    "; \
+    \
+    pythonPkgs=" \
+        ipython3 \
+        python3 \
+        python3-dev \
+        python3-pip \
+    "; \
+    \
+    apt-get update; \
+    apt-get install -y $buildDeps $pythonPkgs --no-install-recommends; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/*; \
+    \
+    ln -s /usr/bin/python3 /usr/bin/python; \
+    ln -s /usr/bin/pydoc3 /usr/bin/pydoc; \
+    \
+    python3 -m pip install --no-cache-dir pipenv; \
+    pipenv install --system --dev --pre; \
+    rm -f Pipfile Pipfile.lock; \
+    \
+    apt-get purge -y --auto-remove $buildDeps;
 
 
 # Prevent python from creating .pyc files and __pycache__ dirs
@@ -78,13 +84,21 @@ ENV PYTHONSTARTUP=/usr/local/share/python/pystartup
 # get a prompt like "I have no name!@<container_id_hash>:/$"
 # since we don't create a user or group.
 RUN set -ex; \
-        echo "PS1='\h:\w\$ '" >> /etc/bash.bashrc; \
-        echo "alias ls='ls --color=auto'" >> /etc/bash.bashrc; \
-        echo "alias grep='grep --color=auto'" >> /etc/bash.bashrc;
+    echo "PS1='\h:\w\$ '" >> /etc/bash.bashrc; \
+    echo "alias ls='ls --color=auto'" >> /etc/bash.bashrc; \
+    echo "alias grep='grep --color=auto'" >> /etc/bash.bashrc;
 
-# Create user named "docker" with empty password (will have uid and gid 1000)
+
+# Create user named "docker" with no password
 RUN useradd --create-home --shell /bin/bash docker \
-    && passwd docker -d
+    && passwd docker -d \
+    && adduser docker sudo
 
-# Change the password to "docker"
-RUN echo 'docker:docker' | chpasswd
+# Don't require a password for sudo
+RUN sed -i 's/^\(%sudo.*\)ALL$/\1NOPASSWD:ALL/' /etc/sudoers
+
+# set an entrypoint script that allows us to
+# dynamically change the uid/gid of the container's user
+COPY entry_point.sh /opt/bin/
+ENTRYPOINT ["/opt/bin/entry_point.sh"]
+CMD ["/opt/bin/entry_point.sh"]

--- a/tew/entry_point.sh
+++ b/tew/entry_point.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Override user ID lookup to cope with being randomly assigned IDs using
+# the -u option to 'docker run'.
+
+# reference:
+# http://blog.dscpl.com.au/2015/12/unknown-user-when-running-docker.html
+
+USER_ID=$(id -u)
+GROUP_ID=$(id -g)
+
+if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1000" ]; then
+
+    # set the new passwd and group files
+    #NSS_WRAPPER_PASSWD=/tmp/passwd.nss_wrapper
+    #NSS_WRAPPER_GROUP=/tmp/group.nss_wrapper
+    NSS_WRAPPER_PASSWD=/etc/passwd
+    NSS_WRAPPER_GROUP=/etc/group
+
+    # overwrite the old uid and gid for the user
+    cat /etc/passwd | sed -e "s/^docker:x:1000:1000:/docker:x:$USER_ID:$GROUP_ID:/" > $NSS_WRAPPER_PASSWD
+    cat /etc/group | sed -e "s/^docker:x:1000:/docker:x:$GROUP_ID:/" > $NSS_WRAPPER_GROUP
+
+    export NSS_WRAPPER_PASSWD
+    export NSS_WRAPPER_GROUP
+
+    LD_PRELOAD=/usr/lib/libnss_wrapper.so
+    export LD_PRELOAD
+fi
+
+# run the user's command
+exec "$@"

--- a/tew/entry_point.sh
+++ b/tew/entry_point.sh
@@ -12,10 +12,8 @@ GROUP_ID=$(id -g)
 if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1000" ]; then
 
     # set the new passwd and group files
-    #NSS_WRAPPER_PASSWD=/tmp/passwd.nss_wrapper
-    #NSS_WRAPPER_GROUP=/tmp/group.nss_wrapper
-    NSS_WRAPPER_PASSWD=/etc/passwd
-    NSS_WRAPPER_GROUP=/etc/group
+    NSS_WRAPPER_PASSWD=/tmp/passwd.nss_wrapper
+    NSS_WRAPPER_GROUP=/tmp/group.nss_wrapper
 
     # overwrite the old uid and gid for the user
     cat /etc/passwd | sed -e "s/^docker:x:1000:1000:/docker:x:$USER_ID:$GROUP_ID:/" > $NSS_WRAPPER_PASSWD


### PR DESCRIPTION
### Description

Use libnss-wrapper to set host user's id in container. Adding an entry script to properly match the uid and gid inside and outside of the container.

Connected to #9

### Testing Notes:

When logging in and ssh'ing, the container should no longer complain about not being able to find the correct uid and gid.

old behavior, note the messages like `groups: cannot find name for group ID 999` and `No user exists for uid 999
`:
```bash
$ docker run --rm --init -it --user=999:999 rstudio/checkrs-tew:0.5.0 bash
groups: cannot find name for group ID 999
e687b6d85c11:/opt/work$ ssh some_other_host -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l user
No user exists for uid 999
e687b6d85c11:/opt/work$
```

new behavior, no gid and uid messages:
```bash
$ docker run --rm --init -it --user=999:999 rstudio/checkrs-tew:0.5.1-prerelease-20210209-2 bash
80f69e1c7b1d:/opt/work$ ssh some_other_host -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l user
ssh: Could not resolve hostname some_other_host: Name or service not known
80f69e1c7b1d:/opt/work$
```